### PR TITLE
Fix for DriverVer without optional version number

### DIFF
--- a/driver_cleanup.py
+++ b/driver_cleanup.py
@@ -68,7 +68,13 @@ class DriverInfo(object):
         else:
             self.__nextParam += 1
         if self.driverDateAndVersion:
-            date, version = self.driverDateAndVersion.split(None, 1)
+            try:
+            	date, version = self.driverDateAndVersion.split(None, 1)
+            	if not version:
+            		raise Exception()
+            except:
+            	date = self.driverDateAndVersion
+            	version = '1'
             self.rawDriverDate = date
             self.driverVersion = tuple(int(x) for x in re.findall(r'(\d+)', version))
 

--- a/driver_cleanup.py
+++ b/driver_cleanup.py
@@ -69,12 +69,9 @@ class DriverInfo(object):
             self.__nextParam += 1
         if self.driverDateAndVersion:
             try:
-            	date, version = self.driverDateAndVersion.split(None, 1)
-            	if not version:
-            		raise Exception()
-            except:
-            	date = self.driverDateAndVersion
-            	version = '1'
+                date, version = self.driverDateAndVersion.split(None, 1)
+            except ValueError:
+                date, version = self.driverDateAndVersion, '1'
             self.rawDriverDate = date
             self.driverVersion = tuple(int(x) for x in re.findall(r'(\d+)', version))
 


### PR DESCRIPTION
According to MS, driver Date is mandatory, but version number is quite optional and can be missing:
https://msdn.microsoft.com/ru-ru/windows/hardware/drivers/install/inf-driverver-directive